### PR TITLE
use LTN Network of Depot stop if request_stop_id is nil for cleanups

### DIFF
--- a/src/scripts/scheduler.lua
+++ b/src/scripts/scheduler.lua
@@ -121,6 +121,17 @@ function scheduler.build(train, request_stop_id)
         return
     end
 
+    if request_stop_id == nil then
+        local depot_record = train.schedule.records[1]
+        local depot_name = depot_record.station
+        if depot_name ~= nil then
+            local depot_stop = train_stops.find_depot(depot_name, surface)
+            if depot_stop ~= nil then
+                request_stop_id = depot_stop.unit_number
+            end
+        end
+    end
+
     local stops = train_stops.get_all_cleanup(ltn.get_network(request_stop_id), trains.count_carriages(train), surface)
 
     if not train_stops.found_any_stops(stops) then


### PR DESCRIPTION
When a delivery has failed the train is send to any cleanup station because request_stop_id is not passed to the scheduler (the train isn't at a train stop).

But the train schedule for an LTN train always has the depot as first entry. So use that entry to find the depot stop and use the network ID if it is an LTN stop and has one. The first ltn stop with the same name on the same surface is used.
