### PR TITLE
Feature icon only

### DIFF
--- a/src/scripts/train_stops.lua
+++ b/src/scripts/train_stops.lua
@@ -4,7 +4,8 @@ local ltn = require("ltn")
 local train_stops = {}
 
 function train_stops.is_cleanup(name)
-    return name ~= nil and string.find(name, "%[virtual%-signal=ltn%-cleanup%-station%]")
+    return name ~= nil and (string.find(name, "%[virtual%-signal=ltn%-cleanup%-station%]")
+                                or string.find(name, "%[img=virtual%-signal/ltn%-cleanup%-station%]"))
 end
 
 function train_stops.found_any_stops(stops)


### PR DESCRIPTION
Train stops that use [virtual-signal=ltn-cleaner-station] will show both an icon and text in messages while using [img=virtual-signal/ltn-cleaner-station] will show only the icon. Allow both for cleanup stations.
